### PR TITLE
Serialise stage promotion delegate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.3</version>
+        <version>2.11</version>
         <relativePath/>
     </parent>
 
@@ -23,9 +23,9 @@
     </licenses>
 
     <properties>
-        <jenkins.version>1.609.3</jenkins.version>
-        <jenkins-test-harness.version>2.1</jenkins-test-harness.version>
-        <java.level>6</java.level>
+        <jenkins.version>2.7.4</jenkins.version>
+        <jenkins-test-harness.version>2.15</jenkins-test-harness.version>
+        <java.level>7</java.level>
         <workflow.version>1.13</workflow.version>
     </properties>
 
@@ -40,6 +40,10 @@
         <pluginRepository>
             <id>maven.jenkins-ci.org</id>
             <url>http://maven.jenkins-ci.org/content/repositories/releases</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/content/repositories/releases</url>
         </pluginRepository>
     </pluginRepositories>
 
@@ -79,7 +83,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>${workflow.version}</version>
+            <version>2.15</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/resources/dsl/stagePromotion.groovy
+++ b/src/main/resources/dsl/stagePromotion.groovy
@@ -1,8 +1,5 @@
 package dsl
 
-/**
- * Created by beazlr02 on 23/04/16.
- */
 def call(body = {}) {
     def config = [:]
     body.resolveStrategy = Closure.DELEGATE_ONLY
@@ -18,7 +15,7 @@ def call(body = {}) {
 
 }
 
-class StagePromotionDelegate {
+class StagePromotionDelegate implements Serializable {
     def map
 
     StagePromotionDelegate(map) {

--- a/src/test/java/uk/co/bbc/mobileci/promoterebuild/pipeline/MobileCIGlobalSerialisesAcrossStages.java
+++ b/src/test/java/uk/co/bbc/mobileci/promoterebuild/pipeline/MobileCIGlobalSerialisesAcrossStages.java
@@ -1,7 +1,5 @@
 package uk.co.bbc.mobileci.promoterebuild.pipeline;
 
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import hudson.model.queue.QueueTaskFuture;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -9,11 +7,8 @@ import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildAction;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Created by beazlr02 on 23/04/16.
@@ -25,7 +20,8 @@ public class MobileCIGlobalSerialisesAcrossStages {
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
-    @Test @Ignore
+    @Test
+    @Ignore(/* Ignored- why is this ignored? */)
     public void promotedJobGlobalCreated() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(

--- a/src/test/java/uk/co/bbc/mobileci/promoterebuild/pipeline/StagePromotionDSLTest.java
+++ b/src/test/java/uk/co/bbc/mobileci/promoterebuild/pipeline/StagePromotionDSLTest.java
@@ -63,4 +63,26 @@ public class StagePromotionDSLTest  {
 
         assertEquals("testing a release", run.getAction(GroovyPostbuildAction.class).getText());
     }
+
+    @Test
+    public void stagePromotionCanOccurInMoreThanOneStage() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "stage \"First Stage\" \n" +
+                "  node {\n" +
+                "    stagePromotion {\n" +
+                "      message 'testing a release'\n" +
+                "    }\n" +
+                "  }" +
+                "" +
+                "\n" +
+                "stage \"Second Stage\" \n" +
+                "  node {\n" +
+                "    stagePromotion {\n" +
+                "      message 'testing a release'\n" +
+                "    }\n" +
+                "  }"
+                , false));
+        p.scheduleBuild2(0);
+    }
 }


### PR DESCRIPTION
The 2.15 version of the workflow-cps plugin (Pipeline: Groovy) causes breakages when the stagePromotion methods are invoked.

This pull request fixes the breakages by making the StagePromotionDelegate serializable
